### PR TITLE
Improve support for skip auction https endpoint submissions

### DIFF
--- a/envs/juno.env
+++ b/envs/juno.env
@@ -38,7 +38,7 @@ ADDRESS_PREFIX = "juno"
 # RPC URL to send skip bundle to
 # Can find the respective url at: 
 # https://skip-protocol.notion.site/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c
-SKIP_RPC_URL = "http://juno-1-api.skip.money/"
+SKIP_RPC_URL = "https://juno-1-api.skip.money/"
 
 # Address to send bid payment to for skip's blockspace auction
 AUCTION_HOUSE_ADDRESS = "juno10g0l3hd9sau3vnjrayjhergcpxemucxcspgnn4"

--- a/envs/terra.env
+++ b/envs/terra.env
@@ -38,7 +38,7 @@ ADDRESS_PREFIX = "terra"
 # RPC URL to send skip bundle to
 # Can find the respective url at: 
 # https://skip-protocol.notion.site/Skip-Configurations-By-Chain-a6076cfa743f4ab38194096403e62f3c
-SKIP_RPC_URL = "http://phoenix-1-api.skip.money/"
+SKIP_RPC_URL = "https://phoenix-1-api.skip.money/"
 
 # Address to send bid payment to for skip's blockspace auction
 AUCTION_HOUSE_ADDRESS = "terra1d5fzv2y8fpdax4u2nnzrn5uf9ghyu5sxr865uy"

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ requests==2.28.1
 rfc3986==1.5.0
 rsa==4.9
 six==1.16.0
-skip-python==0.1.2
+skip-python==0.1.3
 sniffio==1.3.0
 stack-data==0.6.0
 terra-proto==2.1.0


### PR DESCRIPTION
1. Updates requirement of skip-python to 0.1.3 (which supports following redirects if user sends to http endpoint)
2. Updates default url in .envs for the skip auction to use https endpoints