### PR TITLE
fix(terra-contracts): non-working contracts

### DIFF
--- a/skipper-py/envs/terra.env
+++ b/skipper-py/envs/terra.env
@@ -30,7 +30,7 @@ ARB_DENOM = "uluna"
 GAS_LIMIT = 1000000
 
 # Price per gast unit to calculate total fee paid for has
-GAS_PRICE = 0.0125
+GAS_PRICE = 0.015
 
 # Addrex prefix for the network, to be used to generate wallet object
 ADDRESS_PREFIX = "terra"
@@ -51,14 +51,19 @@ AUCTION_HOUSE_ADDRESS = "terra1kdx075ghexr2l6mx4mgn37deshu9fn59r9zq9v"
 AUCTION_BID_PROFIT_PERCENTAGE = 0.5
 
 FACTORY_CONTRACTS = "{'terraswap': 'terra1466nf3zuxpya8q9emxukd7vftaf6h4psr0a07srl5zw74zh84yjqxl5qul',
-                      'phoenix': 'terra1pewdsxywmwurekjwrgvjvxvv0dv2pf8xtdl9ykfce2z0q3gf0k3qr8nezy',
                       'astroport': 'terra14x9fr055x5hvr48hzy2t4q7kvjvfttsvxusa4xsdcy702mnzsvuqprer8r',
                       'white_whale': 'terra1f4cr4sr5eulp3f2us8unu6qv8a5rhjltqsg7ujjx6f2mrlqh923sljwhn3'}"
                       
 ROUTER_CONTRACTS = "{'terraswap': 'terra13ehuhysn5mqjeaheeuew2gjs785f6k7jm8vfsqg3jhtpkwppcmzqcu7chk',
                      'astroport': 'terra1j8hayvehh3yy02c2vtw5fdhz9f4drhtee8p5n5rguvg3nyd6m83qd2y90a',
-                     'phoenix': 'terra1r634fv9kj8s6vjgnrwdha35cwhz6jcpz0h0trhc4yehllvtzzxuq5slv0g',
                      'white_whale': 'terra1p37jrwlaqpklzlu4rwjyjrmzuezdgk3pyuyk2zclc4rda6awkm3qnj6f0a'}"
+
+BLACKLIST_CONTRACTS = "{'terra1suw0nrpgk2a6xa2zvqd9sqmhdfjhjs8ewzywssux0zuzr5yhs5gs08wtpn', 
+                        'terra1yvkfk7scdjraqx8xgrpnh6yj0ruk2287nv0yg736rvmlx6lfghzs8kv48w', 
+                        'terra1he2ejhrzm2pvduqlgzll8u2jl7ztp433n42j4h22z3jrfexpmt7s7g6zaj', 
+                        'terra1m6dll5u25mm0tavssl0khk2jguj3ymm4vff6rnqgvcvzrmfy9k9sajwqty',
+                        'terra1xrgsly3vau8akxv5fsvkgcx8jkqhsmlqv6fhkm4e8vumuzf3u4qsqy8h3k'}"
+
         
 DECODER = "cosmwasm"
 QUERIER = "cosmwasm"

--- a/skipper-py/src/bot.py
+++ b/skipper-py/src/bot.py
@@ -100,16 +100,20 @@ class Bot:
         with open(self.contracts_file) as f:
             self.init_contracts: dict = json.load(f)
         # Initialize the state
-        self.state: State = State()
+        blacklisted_contracts: set = ast.literal_eval(os.environ.get("BLACKLIST_CONTRACTS") or "{}")
+
+        self.state: State = State(blacklisted_contracts = blacklisted_contracts)
         # Update all pool contracts in state
         print("Updating all pool contracts in state...")
+        precheck_pools: bool = ast.literal_eval(os.environ.get("PRECHECK_CONTRACTS") or "False")
         await self.state.set_all_pool_contracts(
                                 init_contracts=self.init_contracts,
                                 router_contracts=self.router_contracts,
                                 querier=self.querier,
                                 creator=self.creator,
                                 factory_contracts=self.factory_contracts,
-                                arb_denom=self.arb_denom
+                                arb_denom=self.arb_denom,
+                                precheck=precheck_pools
                                 )
         # Get list of all contract addresses
         self.contract_list: list = list(self.state.contracts.keys())


### PR DESCRIPTION
Terra-2 changes

some of the pool contracts returned from astroport factory are in error state, querying these pools results in following error

```
terrad q wasm contract-state smart 'terra1suw0nrpgk2a6xa2zvqd9sqmhdfjhjs8ewzywssux0zuzr5yhs5gs08wtpn' '{"pool": {}}'

Error: rpc error: code = Unknown desc = Error calling the VM: Error executing Wasm: Wasmer runtime error: RuntimeError: Error calling into the VM's backend: Panic in FFI call: query wasm contract failed: unknown request
```
